### PR TITLE
feat: improving project page accessibility and keyboard support

### DIFF
--- a/src/Tracey.App/Pages/Projects.razor
+++ b/src/Tracey.App/Pages/Projects.razor
@@ -14,7 +14,7 @@
                 Show archived
             </label>
             <BbButton Variant="ButtonVariant.Default" Size="ButtonSize.Small"
-                      OnClick="@(() => { _showAddClient = !_showAddClient; })"
+                      OnClick="ToggleAddClient"
                       AriaLabel="Add client">
                 + Add client
             </BbButton>
@@ -38,6 +38,7 @@
                 <label for="new-client-name">Name</label>
                 <input id="new-client-name"
                        type="text"
+                       @ref="_clientNameRef"
                        @bind="_newClientName"
                        @bind:event="oninput"
                        @onkeydown="@(e => HandleNewClientKey(e))"
@@ -234,6 +235,7 @@
                                                 {
                                                     <div class="add-task-form">
                                                         <input type="text"
+                                                               @ref="_taskNameRefs[project.Id]"
                                                                @bind="_newTaskName[project.Id]"
                                                                @bind:event="oninput"
                                                                @onkeydown="@(e => HandleNewTaskKey(e, project.Id))"
@@ -259,6 +261,7 @@
                             {
                                 <div class="add-project-form">
                                     <input type="text"
+                                           @ref="_projectNameRefs[client.Id]"
                                            @bind="_newProjectName[client.Id]"
                                            @bind:event="oninput"
                                            @onkeydown="@(e => HandleNewProjectKey(e, client.Id))"
@@ -298,6 +301,13 @@
     private bool _showAddClient;
     private bool _showArchived;
     private bool _loading;
+
+    private ElementReference _clientNameRef;
+    private Dictionary<string, ElementReference> _projectNameRefs = [];
+    private Dictionary<string, ElementReference> _taskNameRefs = [];
+    private bool _pendingFocusClient;
+    private string? _pendingFocusProjectId;
+    private string? _pendingFocusTaskId;
     private string? _errorMessage;
 
     private string _newClientName = string.Empty;
@@ -311,6 +321,25 @@
         expanded ? $"Collapse {name}" : $"Expand {name}";
 
     protected override async Task OnInitializedAsync() => await LoadClients();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_pendingFocusClient)
+        {
+            _pendingFocusClient = false;
+            await _clientNameRef.FocusAsync();
+        }
+        if (_pendingFocusProjectId is not null && _projectNameRefs.TryGetValue(_pendingFocusProjectId, out var projRef))
+        {
+            _pendingFocusProjectId = null;
+            await projRef.FocusAsync();
+        }
+        if (_pendingFocusTaskId is not null && _taskNameRefs.TryGetValue(_pendingFocusTaskId, out var taskRef))
+        {
+            _pendingFocusTaskId = null;
+            await taskRef.FocusAsync();
+        }
+    }
 
     private async Task LoadClients()
     {
@@ -409,6 +438,12 @@
         }
     }
 
+    private void ToggleAddClient()
+    {
+        _showAddClient = !_showAddClient;
+        if (_showAddClient) _pendingFocusClient = true;
+    }
+
     private void HandlePageKeyDown(KeyboardEventArgs e)
     {
         if (e.Key == "Escape" && _showAddClient) CancelAddClient();
@@ -484,6 +519,7 @@
     {
         _showAddProject[clientId] = true;
         _newProjectName.TryAdd(clientId, string.Empty);
+        _pendingFocusProjectId = clientId;
     }
 
     private void HideAddProject(string clientId)
@@ -573,6 +609,7 @@
     {
         _showAddTask[projectId] = true;
         _newTaskName.TryAdd(projectId, string.Empty);
+        _pendingFocusTaskId = projectId;
     }
 
     private void HideAddTask(string projectId)

--- a/src/Tracey.App/Pages/Projects.razor
+++ b/src/Tracey.App/Pages/Projects.razor
@@ -231,6 +231,8 @@
                                                     <div class="add-task-form">
                                                         <input type="text"
                                                                @bind="_newTaskName[project.Id]"
+                                                               @bind:event="oninput"
+                                                               @onkeydown="@(e => HandleNewTaskKey(e, project.Id))"
                                                                placeholder="Task name"
                                                                aria-label="New task name for @project.Name" />
                                                         <BbButton OnClick="() => SaveNewTask(project.Id)" AriaLabel="Save task">Save</BbButton>
@@ -254,6 +256,8 @@
                                 <div class="add-project-form">
                                     <input type="text"
                                            @bind="_newProjectName[client.Id]"
+                                           @bind:event="oninput"
+                                           @onkeydown="@(e => HandleNewProjectKey(e, client.Id))"
                                            placeholder="Project name"
                                            aria-label="New project name for @client.Name" />
                                     <BbButton OnClick="() => SaveNewProject(client.Id)" AriaLabel="Save project">Save</BbButton>
@@ -469,6 +473,12 @@
 
     private void HideAddProject(string clientId) => _showAddProject[clientId] = false;
 
+    private async Task HandleNewProjectKey(KeyboardEventArgs e, string clientId)
+    {
+        if (e.Key == "Enter") await SaveNewProject(clientId);
+        else if (e.Key == "Escape") HideAddProject(clientId);
+    }
+
     private async Task SaveNewProject(string clientId)
     {
         if (!_newProjectName.TryGetValue(clientId, out var name) || string.IsNullOrWhiteSpace(name))
@@ -547,6 +557,12 @@
     }
 
     private void HideAddTask(string projectId) => _showAddTask[projectId] = false;
+
+    private async Task HandleNewTaskKey(KeyboardEventArgs e, string projectId)
+    {
+        if (e.Key == "Enter") await SaveNewTask(projectId);
+        else if (e.Key == "Escape") HideAddTask(projectId);
+    }
 
     private async Task SaveNewTask(string projectId)
     {

--- a/src/Tracey.App/Pages/Projects.razor
+++ b/src/Tracey.App/Pages/Projects.razor
@@ -3,7 +3,7 @@
 
 <PageTitle>Projects</PageTitle>
 
-<div class="projects-page">
+<div class="projects-page" @onkeydown="HandlePageKeyDown">
     <div class="projects-header">
         <h1 class="page-title">Projects</h1>
         <div class="projects-toolbar">
@@ -407,6 +407,11 @@
         {
             _errorMessage = $"Failed to create client: {ex.Message}";
         }
+    }
+
+    private void HandlePageKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape" && _showAddClient) CancelAddClient();
     }
 
     private async Task HandleNewClientKey(KeyboardEventArgs e)

--- a/src/Tracey.App/Pages/Projects.razor
+++ b/src/Tracey.App/Pages/Projects.razor
@@ -39,6 +39,8 @@
                 <input id="new-client-name"
                        type="text"
                        @bind="_newClientName"
+                       @bind:event="oninput"
+                       @onkeydown="@(e => HandleNewClientKey(e))"
                        placeholder="Client name"
                        aria-label="Client name" />
             </div>
@@ -54,6 +56,8 @@
                 <input id="new-client-logo"
                        type="text"
                        @bind="_newClientLogoPath"
+                       @bind:event="oninput"
+                       @onkeydown="@(e => HandleNewClientKey(e))"
                        placeholder="C:\path\to\logo.png"
                        aria-label="Logo path" />
             </div>
@@ -403,6 +407,12 @@
         {
             _errorMessage = $"Failed to create client: {ex.Message}";
         }
+    }
+
+    private async Task HandleNewClientKey(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await SaveNewClient();
+        else if (e.Key == "Escape") CancelAddClient();
     }
 
     private void CancelAddClient()

--- a/src/Tracey.App/Pages/Projects.razor
+++ b/src/Tracey.App/Pages/Projects.razor
@@ -481,7 +481,11 @@
         _newProjectName.TryAdd(clientId, string.Empty);
     }
 
-    private void HideAddProject(string clientId) => _showAddProject[clientId] = false;
+    private void HideAddProject(string clientId)
+    {
+        _showAddProject[clientId] = false;
+        _newProjectName[clientId] = string.Empty;
+    }
 
     private async Task HandleNewProjectKey(KeyboardEventArgs e, string clientId)
     {
@@ -566,7 +570,11 @@
         _newTaskName.TryAdd(projectId, string.Empty);
     }
 
-    private void HideAddTask(string projectId) => _showAddTask[projectId] = false;
+    private void HideAddTask(string projectId)
+    {
+        _showAddTask[projectId] = false;
+        _newTaskName[projectId] = string.Empty;
+    }
 
     private async Task HandleNewTaskKey(KeyboardEventArgs e, string projectId)
     {


### PR DESCRIPTION
- Adds ability to save and cancel client, project and/or task creation via keyboard.
- Text inputs get cleared on Cancel or `ESC`
- Text input for client name, project name and/or task name gets focus on creation.
- Hitting `ESC` on client creation screen without focussed on put closes the "Client" section.

Fixes #10