### PR TITLE
feat: add duration for time entries

### DIFF
--- a/src/Tracey.App/Components/TimeEntryList.razor
+++ b/src/Tracey.App/Components/TimeEntryList.razor
@@ -177,9 +177,13 @@
                                 {
                                     <span class="auto-badge" title="Created automatically by classification">auto</span>
                                 }
-                                <span class="entry-times">
-                                    @FormatTime(entry.StartedAt) – @FormatTime(entry.EndedAt)
-                                </span>
+                                    <span class="entry-times">
+                                        @FormatTime(entry.StartedAt) – @FormatTime(entry.EndedAt)
+                                        @if (!string.IsNullOrEmpty(FormatDuration(entry.StartedAt, entry.EndedAt)))
+                                        {
+                                            <span class="entry-duration"> @FormatDuration(entry.StartedAt, entry.EndedAt)</span>
+                                        }
+                                    </span>
                                 @if (entry.ProjectName != null)
                                 {
                                     <span class="entry-project">
@@ -603,6 +607,19 @@
         if (DateTime.TryParse(isoUtc, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt))
             return dt.ToLocalTime().ToString("HH:mm");
         return isoUtc;
+    }
+    private static string FormatDuration(string? isoStarted, string? isoEnded)
+    {
+        if (isoStarted is null || isoEnded is null) return string.Empty;
+        if (DateTime.TryParse(isoStarted, null, System.Globalization.DateTimeStyles.RoundtripKind, out var s)
+            && DateTime.TryParse(isoEnded, null, System.Globalization.DateTimeStyles.RoundtripKind, out var e))
+        {
+            var span = e.ToLocalTime() - s.ToLocalTime();
+            if (span < TimeSpan.Zero) span = TimeSpan.Zero;
+            var hours = (int)span.TotalHours;
+            return string.Format("{0:D2}:{1:D2}:{2:D2}", hours, span.Minutes, span.Seconds);
+        }
+        return string.Empty;
     }
 
 }

--- a/src/Tracey.App/Components/TimeEntryList.razor.css
+++ b/src/Tracey.App/Components/TimeEntryList.razor.css
@@ -138,6 +138,14 @@
     flex-shrink: 0;
 }
 
+.entry-duration {
+    font-family: ui-monospace, 'SFMono-Regular', 'Cascadia Code', Consolas, monospace;
+    font-size: 0.78rem;
+    color: var(--tracey-text-muted);
+    margin-left: 0.45rem;
+    flex-shrink: 0;
+}
+
 .entry-project {
     font-size: 0.72rem;
     color: var(--tracey-text-muted);


### PR DESCRIPTION
Add a duration next to the start and end time that is shown per time entry.  

Fixes #20