### PR TITLE
feat: add start button when no running time entry

### DIFF
--- a/src-tauri/src/commands/timer.rs
+++ b/src-tauri/src/commands/timer.rs
@@ -39,11 +39,7 @@ pub fn timer_start(
     state: State<'_, AppState>,
     request: TimerStartRequest,
 ) -> Result<TimerStartResponse, String> {
-    // Empty description is valid when a project is selected — the project/task context
-    // already identifies the work. Description is only mandatory in plain (no-project) mode.
-    let empty_without_context =
-        request.description.is_empty() && request.project_id.is_none();
-    if empty_without_context || request.description.len() > 500 {
+    if request.description.len() > 500 {
         return Err("invalid_description".to_string());
     }
 

--- a/src/Tracey.App/Components/QuickEntryBar.razor
+++ b/src/Tracey.App/Components/QuickEntryBar.razor
@@ -41,7 +41,6 @@
             <BbButton Variant="ButtonVariant.Default"
                       Size="ButtonSize.Small"
                       AriaLabel="Start timer"
-                      Disabled="@(string.IsNullOrWhiteSpace(GetDescription()) && _slashMode != SlashMode.Description)"
                       OnClick="StartTimer">
                 Start ↵
             </BbButton>

--- a/src/Tracey.App/Components/QuickEntryBar.razor
+++ b/src/Tracey.App/Components/QuickEntryBar.razor
@@ -658,6 +658,16 @@
 
     private async Task StopTimer()
     {
+        // Persist any description typed while the timer was running
+        if (Timer.CurrentEntryId != null)
+        {
+            var description = GetDescription();
+            if (description != (Timer.CurrentDescription ?? string.Empty))
+            {
+                try { await Tauri.TimeEntryUpdateDescriptionAsync(Timer.CurrentEntryId, description); }
+                catch { /* best-effort: description update failure is non-fatal */ }
+            }
+        }
         await Timer.StopAsync();
         ResetAll();
         await OnTimerStopped.InvokeAsync();

--- a/src/Tracey.App/Components/QuickEntryBar.razor
+++ b/src/Tracey.App/Components/QuickEntryBar.razor
@@ -36,6 +36,16 @@
                 Stop
             </BbButton>
         }
+        else
+        {
+            <BbButton Variant="ButtonVariant.Default"
+                      Size="ButtonSize.Small"
+                      AriaLabel="Start timer"
+                      Disabled="@(string.IsNullOrWhiteSpace(GetDescription()) && _slashMode != SlashMode.Description)"
+                      OnClick="StartTimer">
+                Start ↵
+            </BbButton>
+        }
     </div>
 
     @* Client disambiguation dropdown — shown BEFORE project is resolved *@

--- a/src/Tracey.App/Components/QuickEntryBar.razor
+++ b/src/Tracey.App/Components/QuickEntryBar.razor
@@ -275,8 +275,7 @@
                 {
                     await ConfirmTask(_dropdownIndex < 0 ? 0 : _dropdownIndex);
                 }
-                else if (!string.IsNullOrWhiteSpace(GetDescription()) ||
-                         _slashMode == SlashMode.Description)
+                else
                 {
                     await StartTimer();
                 }
@@ -641,9 +640,6 @@
     {
         if (Timer.IsRunning) return; // guard against repeated Enter presses
         var description = GetDescription();
-        // Allow empty description when project/task already resolved via slash notation
-        if (string.IsNullOrWhiteSpace(description) && _slashMode != SlashMode.Description) return;
-
         _historySuggestions.Clear();
         ClearDropdowns();
 

--- a/src/Tracey.App/Services/TauriIpcService.cs
+++ b/src/Tracey.App/Services/TauriIpcService.cs
@@ -129,6 +129,11 @@ public class TauriIpcService
     public Task<ModifiedAtResponse> TimeEntryUpdateTagsAsync(string entryId, string[] tagIds) =>
         Invoke<ModifiedAtResponse>("time_entry_update", new { request = new { id = entryId, tag_ids = tagIds } });
 
+    /// Partial update — sends only id + description; all other fields preserved by Rust.
+    /// Safe to call on a running entry (ended_at = NULL is preserved).
+    public Task<ModifiedAtResponse> TimeEntryUpdateDescriptionAsync(string entryId, string description) =>
+        Invoke<ModifiedAtResponse>("time_entry_update", new { request = new { id = entryId, description } });
+
     // ── Fuzzy Match ───────────────────────────────────────────────────────
 
     public Task<FuzzyMatchProjectsResponse> FuzzyMatchProjectsAsync(string query, int limit = 8) =>

--- a/src/Tracey.App/Services/TimerStateService.cs
+++ b/src/Tracey.App/Services/TimerStateService.cs
@@ -139,12 +139,21 @@ public class TimerStateService : ITimerStateService
         string? projectName = null, string? clientId = null, string? clientName = null,
         string? taskName = null, string[]? tagIds = null)
     {
-        var result = await _tauri.TimerStartAsync(new TimerStartRequest(
-            description,
-            projectId,
-            taskId,
-            tagIds ?? []
-        ));
+        TimerStartResponse result;
+        try
+        {
+            result = await _tauri.TimerStartAsync(new TimerStartRequest(
+                description,
+                projectId,
+                taskId,
+                tagIds ?? []
+            ));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[TimerStateService] StartAsync failed: {ex.Message}");
+            return;
+        }
 
         _isRunning = true;
         _currentEntryId = result.Id;


### PR DESCRIPTION
A start button is added to let the user start a time entry when no description has been given. It also shows the user that an entry can be started, removing the assumption that a user knows that enter needs to be hit to start a time entry.  

Fixes #22