### PR TITLE
fix: add tags page files and exclusion for it in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -475,6 +475,8 @@ tags
 tags.*
 TAGS
 TAGS.*
+!**/Tags.razor
+!**/Tags.razor.css
 
 ## Python
 __pycache__/

--- a/src/Tracey.App/Pages/Tags.razor
+++ b/src/Tracey.App/Pages/Tags.razor
@@ -1,0 +1,180 @@
+@page "/tags"
+@inject TauriIpcService Tauri
+
+<PageTitle>Tags — Tracey</PageTitle>
+
+<div class="tags-page">
+    <header class="tags-header">
+        <div class="tags-header-text">
+            <h1 class="page-title">Tags</h1>
+            <p class="page-subtitle">Organize time entries with reusable labels.</p>
+        </div>
+        <form class="tag-create-row" @onsubmit="CreateTag" @onsubmit:preventDefault>
+            <input type="text"
+                   @bind="_newTagName"
+                   @bind:event="oninput"
+                   placeholder="New tag name…"
+                   aria-label="New tag name"
+                   class="t-input tag-name-input"
+                   maxlength="50"
+                   disabled="@_creating" />
+            <button type="submit"
+                    class="t-btn t-btn-primary"
+                    disabled="@(_creating || string.IsNullOrWhiteSpace(_newTagName))">
+                Add tag
+            </button>
+        </form>
+    </header>
+
+    @if (_createError != null)
+    {
+        <p class="t-inline-error" role="alert">@_createError</p>
+    }
+
+    @if (_loading)
+    {
+        <p class="t-loading-text" aria-live="polite">Loading…</p>
+    }
+    else if (_tags.Count == 0)
+    {
+        <div class="empty-state-illustration">
+            <span class="empty-state-emoji" aria-hidden="true">🏷️</span>
+            <p class="empty-state-message">No tags yet.</p>
+            <p class="empty-state-hint">Add one above to get started.</p>
+        </div>
+    }
+    else
+    {
+        <ul class="tag-list" role="list" aria-label="Tags">
+            @foreach (var tag in _tags)
+            {
+                var isConfirming = _pendingDeleteTag?.Id == tag.Id;
+                <li class="tag-row @(isConfirming ? "tag-row--confirming" : "")" role="listitem">
+                    @if (isConfirming)
+                    {
+                        <span class="tag-row-name">@tag.Name</span>
+                        <span class="tag-confirm-text">
+                            @(tag.EntryCount > 0
+                                ? $"Removes from {tag.EntryCount} {(tag.EntryCount == 1 ? "entry" : "entries")}."
+                                : "Delete this tag?")
+                        </span>
+                        <button class="t-btn t-btn-danger"
+                                @onclick="ExecuteDelete"
+                                disabled="@_deleting"
+                                aria-label="@($"Confirm delete {tag.Name}")">
+                            Delete
+                        </button>
+                        <button class="t-btn t-btn-secondary"
+                                @onclick="() => _pendingDeleteTag = null"
+                                aria-label="Cancel">
+                            Cancel
+                        </button>
+                    }
+                    else
+                    {
+                        <span class="tag-chip">@tag.Name</span>
+                        <span class="tag-count" aria-label="@tag.EntryCount @(tag.EntryCount == 1 ? "entry" : "entries")">
+                            @tag.EntryCount @(tag.EntryCount == 1 ? "entry" : "entries")
+                        </span>
+                        <button class="tag-btn--remove t-btn t-btn-secondary"
+                                @onclick="() => ConfirmDelete(tag)"
+                                aria-label="@($"Delete {tag.Name}")">
+                            Remove
+                        </button>
+                    }
+                </li>
+            }
+        </ul>
+    }
+</div>
+
+@code {
+    private List<TagItem> _tags = new();
+    private bool _loading = true;
+    private string _newTagName = string.Empty;
+    private string? _createError;
+    private bool _creating;
+    private TagItem? _pendingDeleteTag;
+    private bool _deleting;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTags();
+    }
+
+    private async Task LoadTags()
+    {
+        _loading = true;
+        _createError = null;
+        try
+        {
+            var response = await Tauri.TagListAsync();
+            _tags = response.Tags.ToList();
+        }
+        catch (Exception ex)
+        {
+            _createError = $"Failed to load tags: {ex.Message}";
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task CreateTag()
+    {
+        var name = _newTagName.Trim();
+        if (string.IsNullOrEmpty(name)) return;
+
+        _creating = true;
+        _createError = null;
+        try
+        {
+            await Tauri.TagCreateAsync(name);
+            _newTagName = string.Empty;
+            await LoadTags();
+        }
+        catch (Exception ex) when (ex.Message.Contains("name_conflict"))
+        {
+            _createError = "A tag with this name already exists.";
+        }
+        catch (Exception ex) when (ex.Message.Contains("name_required"))
+        {
+            _createError = "Tag name cannot be empty.";
+        }
+        catch (Exception ex)
+        {
+            _createError = $"Create failed: {ex.Message}";
+        }
+        finally
+        {
+            _creating = false;
+        }
+    }
+
+    private void ConfirmDelete(TagItem tag)
+    {
+        _pendingDeleteTag = tag;
+    }
+
+    private async Task ExecuteDelete()
+    {
+        if (_pendingDeleteTag == null) return;
+        _deleting = true;
+        try
+        {
+            await Tauri.TagDeleteAsync(_pendingDeleteTag.Id);
+            _pendingDeleteTag = null;
+            await LoadTags();
+        }
+        catch (Exception ex)
+        {
+            _createError = $"Delete failed: {ex.Message}";
+            _pendingDeleteTag = null;
+        }
+        finally
+        {
+            _deleting = false;
+        }
+    }
+}

--- a/src/Tracey.App/Pages/Tags.razor.css
+++ b/src/Tracey.App/Pages/Tags.razor.css
@@ -1,0 +1,127 @@
+/* =========================================
+   Tags — Management page
+   ========================================= */
+
+.tags-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+/* ── Header ──────────────────────────────── */
+
+.tags-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.tags-header-text .page-title {
+    margin: 0;
+}
+
+.tags-header-text .page-subtitle {
+    /* inherits global .page-subtitle values */
+    margin: 0.25rem 0 0;
+}
+
+/* ── Create form ─────────────────────────── */
+
+.tag-create-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.tag-name-input {
+    /* width override — base styles handled by .t-input */
+    width: 220px;
+}
+
+/* ── State messages ──────────────────────── */
+
+/* ── Tag list ────────────────────────────── */
+
+.tag-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.tag-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--tracey-surface);
+    border: 1px solid var(--tracey-border);
+    border-radius: 8px;
+    transition: border-color 0.15s;
+}
+
+.tag-row:hover {
+    border-color: #d1d5db;
+}
+
+.tag-row--confirming {
+    border-color: #fca5a5;
+    background: #fef2f2;
+}
+
+/* Normal state */
+.tag-chip {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--tracey-text);
+    flex: 1;
+}
+
+.tag-count {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--tracey-text-muted);
+    background: var(--tracey-surface-alt);
+    border: 1px solid var(--tracey-border);
+    border-radius: 99px;
+    padding: 0.1em 0.6em;
+    line-height: 1.6;
+    min-width: 1.4em;
+    text-align: center;
+    white-space: nowrap;
+}
+
+/* Confirm state */
+.tag-row-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #9b1c1c;
+    flex-shrink: 0;
+}
+
+.tag-confirm-text {
+    font-size: 0.84rem;
+    color: #991b1b;
+    flex: 1;
+}
+
+/* ── Buttons ────────────────────────────── */
+
+/* ── Buttons ── Action buttons use global .t-btn + .t-btn-* classes.
+   Only .tag-btn--remove has page-specific behaviour (hidden until row hover). */
+
+.tag-btn--remove {
+    /* base appearance from .t-btn .t-btn-secondary */
+    margin-left: auto;
+    opacity: 0;
+    transition: background-color 0.15s, border-color 0.15s, color 0.15s, opacity 0.12s;
+}
+
+.tag-row:hover .tag-btn--remove {
+    opacity: 1;
+}


### PR DESCRIPTION
The issue was that the .gitignore file caused both `Tags` files to not be included within the codebase here on GitHub.  

This PR adds an exclusion for those specific files, and adds the files so that the Tags page becomes available.

Fixes #14 